### PR TITLE
ci: fix docker image smoke test to use python --version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,7 +66,7 @@ jobs:
           IMAGE_ID=$(echo ${{ steps.meta.outputs.tags }} | cut -d ',' -f1)
           echo "Testing image $IMAGE_ID"
           docker pull $IMAGE_ID
-          docker run --rm $IMAGE_ID --help
+          docker run --rm $IMAGE_ID python --version
       
       - name: Run architecture tests on built image
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
### Summary
Fixes CI failure in Docker image workflow caused by an invalid container smoke test.

### Root Cause
The workflow attempted to run the image with `--help`, but the container does not expose a CLI entrypoint.

### Fix
Replaced the smoke test with `python --version` to verify the container starts correctly.

Fixes #133