### PR TITLE
feat(proof-reuse): bootstrap PTR certificate transport and lazy pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,39 +1,72 @@
 """Optional proof-reuse bootstrap for direct pytest node selection.
 
-Normal pytest startup discovers the shared plugin through the ``pytest11``
-entry point declared in ``pyproject.toml``.  Disabling entry-point autoload is
-common for focused tests, so this root bootstrap supplies the same plugin in
-that case.  Missing optional proof-reuse packages leave pytest unchanged;
-errors raised from inside an available plugin remain visible.
+Installed distributions discover the shared plugin through the ``pytest11``
+entry point declared in ``pyproject.toml``.  A source checkout has no entry
+point until it is installed, so this root bootstrap supplies the same plugin
+when autoload is disabled or the matching installed entry point is absent.
+Missing optional proof-reuse packages leave pytest unchanged; errors raised
+from inside an available plugin remain visible.
 """
 
 from __future__ import annotations
 
-import importlib
+from importlib import metadata as importlib_metadata
+from importlib.machinery import PathFinder
 import os
 
 _PROOF_REUSE_PLUGIN = "ipfs_accelerate_py.testing.proof_reuse.plugin"
 
 
+def _module_available_without_import(module_name: str) -> bool:
+    """Resolve a dotted module spec without executing parent packages."""
+
+    search_path = None
+    parts = module_name.split(".")
+    for index, part in enumerate(parts):
+        try:
+            # Searching each path segment by basename avoids PathFinder's
+            # normal requirement that a qualified parent already be imported.
+            spec = PathFinder.find_spec(part, search_path)
+        except Exception:
+            return False
+        if spec is None:
+            return False
+        search_path = spec.submodule_search_locations
+        if index < len(parts) - 1 and search_path is None:
+            return False
+    return True
+
+
 def _optional_proof_reuse_plugin() -> tuple[str, ...]:
-    try:
-        importlib.import_module(_PROOF_REUSE_PLUGIN)
-    except ModuleNotFoundError as exc:
-        missing = exc.name or ""
-        if missing and (
-            missing == _PROOF_REUSE_PLUGIN
-            or _PROOF_REUSE_PLUGIN.startswith(f"{missing}.")
-        ):
-            return ()
-        raise
+    if not _module_available_without_import(_PROOF_REUSE_PLUGIN):
+        return ()
     return (_PROOF_REUSE_PLUGIN,)
 
 
-# Avoid registering the same module under both its entry-point name and module
-# name.  With autoload disabled, pytest processes this tuple early enough for
-# the plugin's command-line and ini options to remain available.
-pytest_plugins = (
-    _optional_proof_reuse_plugin()
-    if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
-    else ()
-)
+def _installed_proof_reuse_entry_point() -> bool:
+    """Return whether pytest autoload can discover the shared plugin."""
+
+    try:
+        entry_points = importlib_metadata.entry_points()
+        if hasattr(entry_points, "select"):
+            candidates = entry_points.select(group="pytest11")
+        else:  # pragma: no cover - compatibility with older importlib.metadata
+            candidates = entry_points.get("pytest11", ())
+    except Exception:
+        return False
+    return any(
+        getattr(entry_point, "value", None) == _PROOF_REUSE_PLUGIN
+        for entry_point in candidates
+    )
+
+
+def pytest_load_initial_conftests(early_config, parser, args):  # noqa: ARG001
+    """Register the optional proof-reuse plugin when discovery needs a hand."""
+
+    if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") not in {"1", "true", "yes"}:
+        if _installed_proof_reuse_entry_point():
+            return
+    plugins = _optional_proof_reuse_plugin()
+    if not plugins:
+        return
+    early_config.pluginmanager.import_plugin(plugins[0])

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,39 @@
+"""Optional proof-reuse bootstrap for direct pytest node selection.
+
+Normal pytest startup discovers the shared plugin through the ``pytest11``
+entry point declared in ``pyproject.toml``.  Disabling entry-point autoload is
+common for focused tests, so this root bootstrap supplies the same plugin in
+that case.  Missing optional proof-reuse packages leave pytest unchanged;
+errors raised from inside an available plugin remain visible.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+_PROOF_REUSE_PLUGIN = "ipfs_accelerate_py.testing.proof_reuse.plugin"
+
+
+def _optional_proof_reuse_plugin() -> tuple[str, ...]:
+    try:
+        importlib.import_module(_PROOF_REUSE_PLUGIN)
+    except ModuleNotFoundError as exc:
+        missing = exc.name or ""
+        if missing and (
+            missing == _PROOF_REUSE_PLUGIN
+            or _PROOF_REUSE_PLUGIN.startswith(f"{missing}.")
+        ):
+            return ()
+        raise
+    return (_PROOF_REUSE_PLUGIN,)
+
+
+# Avoid registering the same module under both its entry-point name and module
+# name.  With autoload disabled, pytest processes this tuple early enough for
+# the plugin's command-line and ini options to remain available.
+pytest_plugins = (
+    _optional_proof_reuse_plugin()
+    if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+    else ()
+)

--- a/ipfs_kit_py/core/service_manager.py
+++ b/ipfs_kit_py/core/service_manager.py
@@ -19,7 +19,6 @@ from typing import Dict, List, Optional, Callable, Any
 from dataclasses import dataclass
 from enum import Enum
 import json
-import requests
 from pathlib import Path
 
 # Setup logging
@@ -250,9 +249,10 @@ class ServiceManager:
             return self.is_service_running(service_name)
         
         try:
+            import requests
             response = requests.get(config.health_check_url, timeout=5)
             return response.status_code == 200
-        except requests.RequestException:
+        except Exception:
             return False
     
     def _validate_config(self, config: ServiceConfig) -> bool:
@@ -436,10 +436,11 @@ class IPFSServiceManager(ServiceManager):
             return None
         
         try:
+            import requests
             response = requests.get("http://127.0.0.1:5001/api/v0/id", timeout=5)
             if response.status_code == 200:
                 return response.json()
-        except requests.RequestException:
+        except Exception:
             pass
         
         return None
@@ -449,6 +450,15 @@ import os
 import sys
 
 def _should_disable_monitoring() -> bool:
+    # Importing ipfs_kit_py is a cold operation.  Background monitoring is
+    # enabled only by an application that explicitly owns that lifecycle.
+    if os.environ.get("IPFS_KIT_ENABLE_SERVICE_MONITORING", "").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return True
     if os.environ.get("IPFS_KIT_FAST_INIT") == "1":
         return True
     if os.environ.get("IPFS_KIT_DISABLE_SERVICE_MANAGER") == "1":

--- a/ipfs_kit_py/proof_certificate_store.py
+++ b/ipfs_kit_py/proof_certificate_store.py
@@ -1,0 +1,775 @@
+"""Strict optional transport for proof-backed test certificates.
+
+The transport is deliberately smaller than the authoritative certificate
+store in ``ipfs_accelerate_py``.  It moves immutable bytes by CID, but never
+decides whether those bytes prove that a test may be reused.
+
+Safety properties:
+
+* CID text is decoded and its sha2-256 multihash is checked against the exact
+  bytes.  The legacy ``ipfs_multiformats`` testing pseudo-CIDs are not used.
+* Local storage is opt-in, bounded, atomically published, and rehashed after
+  publication.
+* IPFS is opt-in through an already-created client or explicit callables.
+  This module never starts a daemon and never discovers or creates ``~/.ipfs``.
+* Every IPFS exception, malformed response, oversized response, or hash
+  mismatch is a typed miss.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import os
+import stat
+import tempfile
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Final
+
+TEST_CERTIFICATE_STORE_TRANSPORT_INTERFACE: Final = (
+    "TestCertificateStoreTransport@1"
+)
+TEST_CERTIFICATE_STORE_TRANSPORT_SCHEMA: Final = (
+    "ipfs_kit_py/test-certificate-store-transport@1"
+)
+TEST_CERTIFICATE_STORE_TRANSPORT_SCHEMA_VERSION: Final = (
+    TEST_CERTIFICATE_STORE_TRANSPORT_INTERFACE
+)
+
+DEFAULT_MAX_CERTIFICATE_BYTES: Final = 1_048_576
+DEFAULT_MAX_BLOB_BYTES: Final = DEFAULT_MAX_CERTIFICATE_BYTES
+
+_CIDV1: Final = 1
+_RAW_CODEC: Final = 0x55
+_SHA2_256: Final = 0x12
+_SHA2_256_SIZE: Final = 32
+_BASE58_ALPHABET: Final = (
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+)
+_BASE58_INDEX: Final = {character: index for index, character in enumerate(_BASE58_ALPHABET)}
+_THREAD_LOCKS: dict[str, threading.RLock] = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+class CertificateTransportStatus(str, Enum):
+    STORED = "stored"
+    HIT = "hit"
+    MISS = "miss"
+    REJECTED = "rejected"
+    ERROR = "error"
+
+
+class CertificateTransportReason(str, Enum):
+    OK = "ok"
+    ALREADY_EXISTS = "already_exists"
+    UNAVAILABLE = "unavailable"
+    MALFORMED = "malformed"
+    OVER_BUDGET = "over_budget"
+    CID_MISMATCH = "cid_mismatch"
+    NOT_FOUND = "not_found"
+    INTEGRITY_FAILED = "integrity_failed"
+    SYMLINK_REJECTED = "symlink_rejected"
+    PATH_ESCAPE = "path_escape"
+    IO_ERROR = "io_error"
+    IPFS_ERROR = "ipfs_error"
+    IPFS_RESPONSE_INVALID = "ipfs_response_invalid"
+
+
+class CertificateTransportError(ValueError):
+    """A CID or transport configuration violates the closed contract."""
+
+
+@dataclass(frozen=True)
+class DecodedCertificateCID:
+    """The security-relevant projection of a decoded CID."""
+
+    text: str
+    version: int
+    codec: int
+    multihash_code: int
+    digest: bytes
+    base: str
+
+    def verifies(self, data: bytes) -> bool:
+        return type(data) is bytes and hashlib.sha256(data).digest() == self.digest
+
+
+@dataclass(frozen=True)
+class CertificateTransportPutResult:
+    stored: bool
+    cid: str
+    reason_code: CertificateTransportReason
+    byte_length: int = 0
+    local_stored: bool = False
+    ipfs_stored: bool = False
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.stored
+
+
+@dataclass(frozen=True)
+class CertificateTransportGetResult:
+    status: CertificateTransportStatus
+    cid: str
+    reason_code: CertificateTransportReason
+    data: bytes | None = None
+    byte_length: int = 0
+    source: str = ""
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.hit
+
+    @property
+    def hit(self) -> bool:
+        return self.status is CertificateTransportStatus.HIT and self.data is not None
+
+
+# Familiar aliases for callers already using the accelerator-side CAS names.
+CasPutResult = CertificateTransportPutResult
+CasGetResult = CertificateTransportGetResult
+
+
+def _encode_varint(value: int) -> bytes:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise CertificateTransportError("varint value must be a non-negative integer")
+    encoded = bytearray()
+    while value >= 0x80:
+        encoded.append((value & 0x7F) | 0x80)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def _decode_varint(data: bytes, offset: int) -> tuple[int, int]:
+    value = 0
+    shift = 0
+    start = offset
+    for _ in range(10):
+        if offset >= len(data):
+            raise CertificateTransportError("CID contains a truncated varint")
+        octet = data[offset]
+        offset += 1
+        value |= (octet & 0x7F) << shift
+        if not octet & 0x80:
+            if data[start:offset] != _encode_varint(value):
+                raise CertificateTransportError("CID contains a non-canonical varint")
+            return value, offset
+        shift += 7
+    raise CertificateTransportError("CID varint is too long")
+
+
+def _base58_decode(text: str) -> bytes:
+    if not text:
+        raise CertificateTransportError("base58 payload must not be empty")
+    value = 0
+    try:
+        for character in text:
+            value = value * 58 + _BASE58_INDEX[character]
+    except KeyError as exc:
+        raise CertificateTransportError("CID contains invalid base58 text") from exc
+    body = (
+        value.to_bytes((value.bit_length() + 7) // 8, "big")
+        if value
+        else b""
+    )
+    return b"\x00" * (len(text) - len(text.lstrip("1"))) + body
+
+
+def _base58_encode(data: bytes) -> str:
+    leading = len(data) - len(data.lstrip(b"\x00"))
+    value = int.from_bytes(data, "big")
+    encoded = ""
+    while value:
+        value, remainder = divmod(value, 58)
+        encoded = _BASE58_ALPHABET[remainder] + encoded
+    return "1" * leading + encoded
+
+
+def _base32_decode(text: str) -> bytes:
+    if not text or text != text.lower():
+        raise CertificateTransportError(
+            "base32 CID must use nonempty canonical lowercase text"
+        )
+    if any(character not in "abcdefghijklmnopqrstuvwxyz234567" for character in text):
+        raise CertificateTransportError("CID contains invalid base32 text")
+    padding = "=" * ((8 - len(text) % 8) % 8)
+    try:
+        decoded = base64.b32decode((text.upper() + padding).encode("ascii"))
+    except (binascii.Error, ValueError) as exc:
+        raise CertificateTransportError("CID base32 payload is not decodable") from exc
+    canonical = base64.b32encode(decoded).decode("ascii").lower().rstrip("=")
+    if canonical != text:
+        raise CertificateTransportError("CID is not canonical base32")
+    return decoded
+
+
+def decode_certificate_cid(value: str) -> DecodedCertificateCID:
+    """Decode one canonical CID carrying a full sha2-256 multihash.
+
+    Canonical lowercase base32 CIDv1 is the generated form.  Canonical
+    base58btc CIDv1 and CIDv0 are accepted so externally supplied block CIDs
+    can still be rehashed.  No prefix-only or synthetic CID is admitted.
+    """
+
+    if type(value) is not str or not value or value.strip() != value:
+        raise CertificateTransportError("CID must be a nonempty canonical string")
+    if len(value) > 256 or "/" in value or "\\" in value or "\x00" in value:
+        raise CertificateTransportError("CID contains unsafe text")
+
+    if value.startswith("b"):
+        raw = _base32_decode(value[1:])
+        base_name = "base32"
+        version, offset = _decode_varint(raw, 0)
+        if version != _CIDV1:
+            raise CertificateTransportError("only CIDv1 is valid with multibase")
+        codec, offset = _decode_varint(raw, offset)
+    elif value.startswith("z"):
+        raw = _base58_decode(value[1:])
+        if "z" + _base58_encode(raw) != value:
+            raise CertificateTransportError("CID is not canonical base58btc")
+        base_name = "base58btc"
+        version, offset = _decode_varint(raw, 0)
+        if version != _CIDV1:
+            raise CertificateTransportError("only CIDv1 is valid with multibase")
+        codec, offset = _decode_varint(raw, offset)
+    elif value.startswith("Qm"):
+        raw = _base58_decode(value)
+        if _base58_encode(raw) != value:
+            raise CertificateTransportError("CIDv0 is not canonical base58btc")
+        # CIDv0 is the bare dag-pb multihash.
+        version, codec, offset, base_name = 0, 0x70, 0, "base58btc"
+    else:
+        raise CertificateTransportError(
+            "CID must be canonical CIDv1 multibase or CIDv0 base58btc"
+        )
+
+    multihash_code, offset = _decode_varint(raw, offset)
+    digest_size, offset = _decode_varint(raw, offset)
+    digest = raw[offset:]
+    if codec <= 0:
+        raise CertificateTransportError("CID codec must be a positive multicodec")
+    if multihash_code != _SHA2_256 or digest_size != _SHA2_256_SIZE:
+        raise CertificateTransportError(
+            "certificate CIDs require a full 32-byte sha2-256 multihash"
+        )
+    if len(digest) != digest_size:
+        raise CertificateTransportError("CID multihash is truncated or has trailing data")
+    return DecodedCertificateCID(
+        value, version, codec, multihash_code, digest, base_name
+    )
+
+
+def cid_for_certificate_bytes(data: bytes, *, codec: int = _RAW_CODEC) -> str:
+    """Return a canonical raw CIDv1 for exact bytes."""
+
+    if type(data) is not bytes:
+        raise CertificateTransportError("certificate payload must be exact bytes")
+    if isinstance(codec, bool) or not isinstance(codec, int) or codec <= 0:
+        raise CertificateTransportError("codec must be a positive multicodec integer")
+    raw = (
+        _encode_varint(_CIDV1)
+        + _encode_varint(codec)
+        + _encode_varint(_SHA2_256)
+        + _encode_varint(_SHA2_256_SIZE)
+        + hashlib.sha256(data).digest()
+    )
+    return "b" + base64.b32encode(raw).decode("ascii").lower().rstrip("=")
+
+
+def verify_certificate_cid(cid: str, data: bytes) -> bool:
+    """Return whether ``cid`` carries the sha2-256 digest of exact ``data``."""
+
+    if type(data) is not bytes:
+        return False
+    try:
+        return decode_certificate_cid(cid).verifies(data)
+    except CertificateTransportError:
+        return False
+
+
+def _thread_lock(root: Path) -> threading.RLock:
+    key = os.path.abspath(os.fspath(root))
+    with _THREAD_LOCKS_GUARD:
+        return _THREAD_LOCKS.setdefault(key, threading.RLock())
+
+
+def _extract_ipfs_cid(value: Any) -> str | None:
+    if type(value) is str:
+        return value
+    if isinstance(value, Mapping):
+        for key in ("cid", "CID", "Hash", "Key"):
+            candidate = value.get(key)
+            if type(candidate) is str:
+                return candidate
+            if isinstance(candidate, Mapping) and type(candidate.get("/")) is str:
+                return candidate["/"]
+    return None
+
+
+def _extract_ipfs_bytes(value: Any, *, maximum: int) -> bytes | None:
+    if type(value) is bytes:
+        return value if len(value) <= maximum else None
+    if isinstance(value, bytearray):
+        return bytes(value) if len(value) <= maximum else None
+    if isinstance(value, memoryview):
+        return value.tobytes() if value.nbytes <= maximum else None
+    if hasattr(value, "read"):
+        try:
+            data = value.read(maximum + 1)
+        except BaseException:
+            return None
+        return data if type(data) is bytes and len(data) <= maximum else None
+    return None
+
+
+class IpfsKitProofCertificateStore:
+    """Optional local/IPFS exact-byte transport.
+
+    ``local_root`` and ``ipfs_client`` default to ``None``.  Consequently a
+    default instance has no filesystem or network side effects.  An injected
+    IPFS client is assumed to refer to an already-running service; this class
+    only calls block get/put style methods and has no daemon-management path.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        local_root: str | os.PathLike[str] | None = None,
+        *,
+        ipfs_client: Any | None = None,
+        ipfs_get: Callable[[str], Any] | None = None,
+        ipfs_put: Callable[[bytes], Any] | None = None,
+        max_blob_bytes: int = DEFAULT_MAX_BLOB_BYTES,
+        cache_ipfs_reads: bool = True,
+    ) -> None:
+        if (
+            isinstance(max_blob_bytes, bool)
+            or not isinstance(max_blob_bytes, int)
+            or max_blob_bytes <= 0
+        ):
+            raise ValueError("max_blob_bytes must be a positive integer")
+        if ipfs_get is not None and not callable(ipfs_get):
+            raise TypeError("ipfs_get must be callable")
+        if ipfs_put is not None and not callable(ipfs_put):
+            raise TypeError("ipfs_put must be callable")
+        self.local_root = Path(local_root).absolute() if local_root is not None else None
+        self.max_blob_bytes = max_blob_bytes
+        self.cache_ipfs_reads = bool(cache_ipfs_reads)
+        self._ipfs_get = ipfs_get or self._client_method(
+            ipfs_client, ("block_get", "get_block", "cat")
+        )
+        self._ipfs_put = ipfs_put or self._client_method(
+            ipfs_client, ("block_put", "put_block", "add_bytes")
+        )
+
+    @staticmethod
+    def _client_method(client: Any | None, names: tuple[str, ...]) -> Callable[..., Any] | None:
+        if client is None:
+            return None
+        for name in names:
+            method = getattr(client, name, None)
+            if callable(method):
+                return method
+        return None
+
+    @property
+    def local_enabled(self) -> bool:
+        return self.local_root is not None
+
+    @property
+    def ipfs_read_enabled(self) -> bool:
+        return self._ipfs_get is not None
+
+    @property
+    def ipfs_write_enabled(self) -> bool:
+        return self._ipfs_put is not None
+
+    def _blob_path(self, cid: str) -> Path:
+        if self.local_root is None:
+            raise CertificateTransportError("local transport is disabled")
+        # Decoding makes the token path-safe; the digest shard is bounded.
+        parsed = decode_certificate_cid(cid)
+        shard = parsed.digest.hex()[:2]
+        return self.local_root / "certificates" / shard / f"{cid}.blob"
+
+    def _safe_local_path(self, cid: str, *, create_parent: bool) -> Path:
+        if self.local_root is None:
+            raise CertificateTransportError("local transport is disabled")
+        root = self.local_root
+        if root.is_symlink():
+            raise CertificateTransportError(CertificateTransportReason.SYMLINK_REJECTED.value)
+        path = self._blob_path(cid)
+        if create_parent:
+            root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if root.is_symlink():
+                raise CertificateTransportError(
+                    CertificateTransportReason.SYMLINK_REJECTED.value
+                )
+        current = root
+        for part in path.relative_to(root).parts[:-1]:
+            current = current / part
+            if current.is_symlink():
+                raise CertificateTransportError(
+                    CertificateTransportReason.SYMLINK_REJECTED.value
+                )
+            if create_parent:
+                current.mkdir(mode=0o700, exist_ok=True)
+                # Check again after mkdir so a concurrently-created symlink is
+                # rejected before any child path is created through it.
+                if current.is_symlink():
+                    raise CertificateTransportError(
+                        CertificateTransportReason.SYMLINK_REJECTED.value
+                    )
+                if not current.is_dir():
+                    raise CertificateTransportError(
+                        CertificateTransportReason.PATH_ESCAPE.value
+                    )
+        if path.is_symlink():
+            raise CertificateTransportError(
+                CertificateTransportReason.SYMLINK_REJECTED.value
+            )
+        if path.parent.exists():
+            try:
+                path.parent.resolve(strict=True).relative_to(root.resolve(strict=True))
+            except (OSError, ValueError) as exc:
+                raise CertificateTransportError(
+                    CertificateTransportReason.PATH_ESCAPE.value
+                ) from exc
+        return path
+
+    def _read_local(self, cid: str) -> CertificateTransportGetResult:
+        try:
+            path = self._safe_local_path(cid, create_parent=False)
+        except CertificateTransportError as exc:
+            reason = (
+                CertificateTransportReason.SYMLINK_REJECTED
+                if str(exc) == CertificateTransportReason.SYMLINK_REJECTED.value
+                else CertificateTransportReason.PATH_ESCAPE
+            )
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS, cid, reason
+            )
+        if not path.exists():
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                cid,
+                CertificateTransportReason.NOT_FOUND,
+            )
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags)
+            with os.fdopen(descriptor, "rb") as stream:
+                metadata = os.fstat(stream.fileno())
+                if not stat.S_ISREG(metadata.st_mode):
+                    return CertificateTransportGetResult(
+                        CertificateTransportStatus.MISS,
+                        cid,
+                        CertificateTransportReason.MALFORMED,
+                    )
+                if metadata.st_size > self.max_blob_bytes:
+                    return CertificateTransportGetResult(
+                        CertificateTransportStatus.MISS,
+                        cid,
+                        CertificateTransportReason.OVER_BUDGET,
+                        byte_length=metadata.st_size,
+                    )
+                data = stream.read(self.max_blob_bytes + 1)
+        except OSError:
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                cid,
+                CertificateTransportReason.IO_ERROR,
+            )
+        if len(data) > self.max_blob_bytes:
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                cid,
+                CertificateTransportReason.OVER_BUDGET,
+                byte_length=len(data),
+            )
+        if not verify_certificate_cid(cid, data):
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                cid,
+                CertificateTransportReason.INTEGRITY_FAILED,
+                byte_length=len(data),
+            )
+        return CertificateTransportGetResult(
+            CertificateTransportStatus.HIT,
+            cid,
+            CertificateTransportReason.OK,
+            data,
+            len(data),
+            "local",
+        )
+
+    def _write_local(self, cid: str, data: bytes) -> CertificateTransportPutResult:
+        assert self.local_root is not None
+        try:
+            path = self._safe_local_path(cid, create_parent=True)
+        except (CertificateTransportError, OSError) as exc:
+            reason = (
+                CertificateTransportReason.SYMLINK_REJECTED
+                if str(exc) == CertificateTransportReason.SYMLINK_REJECTED.value
+                else CertificateTransportReason.PATH_ESCAPE
+            )
+            return CertificateTransportPutResult(False, cid, reason, len(data))
+
+        with _thread_lock(self.local_root):
+            if path.exists() or path.is_symlink():
+                existing = self._read_local(cid)
+                if existing.hit and existing.data == data:
+                    return CertificateTransportPutResult(
+                        True,
+                        cid,
+                        CertificateTransportReason.ALREADY_EXISTS,
+                        len(data),
+                        local_stored=True,
+                    )
+                return CertificateTransportPutResult(
+                    False,
+                    cid,
+                    existing.reason_code,
+                    len(data),
+                )
+            descriptor = -1
+            temporary_name = ""
+            try:
+                descriptor, temporary_name = tempfile.mkstemp(
+                    prefix=f".{cid}.", suffix=".tmp", dir=path.parent
+                )
+                with os.fdopen(descriptor, "wb") as stream:
+                    descriptor = -1
+                    stream.write(data)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.chmod(temporary_name, 0o600)
+                os.replace(temporary_name, path)
+                temporary_name = ""
+                try:
+                    directory = os.open(path.parent, os.O_RDONLY)
+                    try:
+                        os.fsync(directory)
+                    finally:
+                        os.close(directory)
+                except OSError:
+                    pass
+            except OSError:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                if temporary_name:
+                    try:
+                        os.unlink(temporary_name)
+                    except OSError:
+                        pass
+                return CertificateTransportPutResult(
+                    False, cid, CertificateTransportReason.IO_ERROR, len(data)
+                )
+            readback = self._read_local(cid)
+            if not readback.hit or readback.data != data:
+                return CertificateTransportPutResult(
+                    False,
+                    cid,
+                    CertificateTransportReason.INTEGRITY_FAILED,
+                    len(data),
+                )
+            return CertificateTransportPutResult(
+                True,
+                cid,
+                CertificateTransportReason.OK,
+                len(data),
+                local_stored=True,
+            )
+
+    def put_bytes(
+        self,
+        data: bytes,
+        *,
+        claimed_cid: str | None = None,
+        cid: str | None = None,
+    ) -> CertificateTransportPutResult:
+        """Verify and publish exact bytes to the explicitly enabled backends."""
+
+        if claimed_cid is not None and cid is not None and claimed_cid != cid:
+            return CertificateTransportPutResult(
+                False, claimed_cid, CertificateTransportReason.MALFORMED
+            )
+        claim = claimed_cid if claimed_cid is not None else cid
+        if type(data) is not bytes:
+            return CertificateTransportPutResult(
+                False, claim or "", CertificateTransportReason.MALFORMED
+            )
+        if len(data) > self.max_blob_bytes:
+            return CertificateTransportPutResult(
+                False,
+                claim or "",
+                CertificateTransportReason.OVER_BUDGET,
+                len(data),
+            )
+        target = claim or cid_for_certificate_bytes(data)
+        try:
+            parsed = decode_certificate_cid(target)
+        except CertificateTransportError:
+            return CertificateTransportPutResult(
+                False, target, CertificateTransportReason.MALFORMED, len(data)
+            )
+        if not parsed.verifies(data):
+            return CertificateTransportPutResult(
+                False, target, CertificateTransportReason.CID_MISMATCH, len(data)
+            )
+
+        local_result: CertificateTransportPutResult | None = None
+        if self.local_root is not None:
+            local_result = self._write_local(target, data)
+
+        ipfs_stored = False
+        ipfs_reason = CertificateTransportReason.UNAVAILABLE
+        if self._ipfs_put is not None:
+            try:
+                response_cid = _extract_ipfs_cid(self._ipfs_put(data))
+            except BaseException:
+                response_cid = None
+                ipfs_reason = CertificateTransportReason.IPFS_ERROR
+            else:
+                if response_cid is None:
+                    ipfs_reason = CertificateTransportReason.IPFS_RESPONSE_INVALID
+                else:
+                    try:
+                        returned = decode_certificate_cid(response_cid)
+                    except CertificateTransportError:
+                        ipfs_reason = CertificateTransportReason.IPFS_RESPONSE_INVALID
+                    else:
+                        ipfs_stored = returned.verifies(data) and returned.digest == parsed.digest
+                        ipfs_reason = (
+                            CertificateTransportReason.OK
+                            if ipfs_stored
+                            else CertificateTransportReason.CID_MISMATCH
+                        )
+
+        stored = bool(local_result and local_result.stored) or ipfs_stored
+        if stored:
+            reason = (
+                local_result.reason_code
+                if local_result is not None and local_result.stored
+                else CertificateTransportReason.OK
+            )
+        elif local_result is not None:
+            reason = local_result.reason_code
+        else:
+            reason = ipfs_reason
+        return CertificateTransportPutResult(
+            stored,
+            target,
+            reason,
+            len(data),
+            bool(local_result and local_result.local_stored),
+            ipfs_stored,
+        )
+
+    def get_bytes(self, cid: str) -> CertificateTransportGetResult:
+        """Fetch bounded exact bytes; every backend fault is a safe miss."""
+
+        try:
+            parsed = decode_certificate_cid(cid)
+        except CertificateTransportError:
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                cid if type(cid) is str else "",
+                CertificateTransportReason.MALFORMED,
+            )
+
+        if self.local_root is not None:
+            local = self._read_local(parsed.text)
+            if local.hit:
+                return local
+            # Integrity and path failures must not be hidden by a remote fetch.
+            if local.reason_code not in {
+                CertificateTransportReason.NOT_FOUND,
+                CertificateTransportReason.IO_ERROR,
+            }:
+                return local
+
+        if self._ipfs_get is None:
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                parsed.text,
+                CertificateTransportReason.NOT_FOUND,
+            )
+        try:
+            response = self._ipfs_get(parsed.text)
+        except BaseException:
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                parsed.text,
+                CertificateTransportReason.IPFS_ERROR,
+            )
+        data = _extract_ipfs_bytes(response, maximum=self.max_blob_bytes)
+        if data is None:
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                parsed.text,
+                CertificateTransportReason.IPFS_RESPONSE_INVALID,
+            )
+        if not parsed.verifies(data):
+            return CertificateTransportGetResult(
+                CertificateTransportStatus.MISS,
+                parsed.text,
+                CertificateTransportReason.INTEGRITY_FAILED,
+                byte_length=len(data),
+            )
+        if self.local_root is not None and self.cache_ipfs_reads:
+            cached = self._write_local(parsed.text, data)
+            if not cached.stored:
+                return CertificateTransportGetResult(
+                    CertificateTransportStatus.MISS,
+                    parsed.text,
+                    cached.reason_code,
+                    byte_length=len(data),
+                )
+        return CertificateTransportGetResult(
+            CertificateTransportStatus.HIT,
+            parsed.text,
+            CertificateTransportReason.OK,
+            data,
+            len(data),
+            "ipfs",
+        )
+
+    def put(self, data: bytes, *, cid: str | None = None) -> str | None:
+        result = self.put_bytes(data, claimed_cid=cid)
+        return result.cid if result.stored else None
+
+    def get(self, cid: str) -> bytes | None:
+        return self.get_bytes(cid).data
+
+    def has(self, cid: str) -> bool:
+        return self.get_bytes(cid).hit
+
+
+__all__ = [
+    "CasGetResult",
+    "CasPutResult",
+    "CertificateTransportError",
+    "CertificateTransportGetResult",
+    "CertificateTransportPutResult",
+    "CertificateTransportReason",
+    "CertificateTransportStatus",
+    "DecodedCertificateCID",
+    "DEFAULT_MAX_BLOB_BYTES",
+    "DEFAULT_MAX_CERTIFICATE_BYTES",
+    "IpfsKitProofCertificateStore",
+    "TEST_CERTIFICATE_STORE_TRANSPORT_INTERFACE",
+    "TEST_CERTIFICATE_STORE_TRANSPORT_SCHEMA",
+    "TEST_CERTIFICATE_STORE_TRANSPORT_SCHEMA_VERSION",
+    "cid_for_certificate_bytes",
+    "decode_certificate_cid",
+    "verify_certificate_cid",
+]

--- a/ipfs_kit_py/test_reuse_capabilities.py
+++ b/ipfs_kit_py/test_reuse_capabilities.py
@@ -1,0 +1,450 @@
+"""Lazy, bounded facts for optional Kubo, Lotus, and Iroh integrations.
+
+Discovery is intentionally cold: it checks only whether explicitly named
+executables are discoverable.  It never executes a binary, imports a provider,
+connects to a service, starts a daemon, or examines a user's IPFS directory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import shutil
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Final
+
+TEST_REUSE_CAPABILITY_REPORT_SCHEMA: Final = "TestReuseCapabilityReport@1"
+TEST_REUSE_CAPABILITY_REPORT_SCHEMA_VERSION: Final = (
+    TEST_REUSE_CAPABILITY_REPORT_SCHEMA
+)
+TEST_REUSE_CAPABILITY_REPORT_VERSION: Final = 1
+DEFAULT_CAPABILITY_TIMEOUT_SECONDS: Final = 0.5
+DEFAULT_CAPABILITY_MAX_CHECKS: Final = 3
+
+_DISABLED_VALUES = frozenset({"0", "disabled", "false", "no", "off"})
+_ENABLED_VALUES = frozenset({"1", "enabled", "on", "true", "yes"})
+
+
+class KitTestReuseCapabilityStatus(str, Enum):
+    AVAILABLE = "available"
+    DISABLED = "disabled"
+    MISSING = "missing"
+    INCOMPATIBLE = "incompatible"
+    UNKNOWN = "unknown"
+
+
+class KitTestReuseCapabilityName(str, Enum):
+    KUBO = "kubo"
+    LOTUS = "lotus"
+    IROH = "iroh"
+
+
+_CAPABILITY_ORDER: Final = tuple(KitTestReuseCapabilityName)
+_EXECUTABLES: Final = {
+    KitTestReuseCapabilityName.KUBO: "ipfs",
+    KitTestReuseCapabilityName.LOTUS: "lotus",
+    KitTestReuseCapabilityName.IROH: "iroh",
+}
+
+
+def _fingerprint(
+    capability: KitTestReuseCapabilityName,
+    status: KitTestReuseCapabilityStatus,
+    executable: str,
+    discovered_path: str | None,
+) -> str:
+    payload = json.dumps(
+        {
+            "capability_id": capability.value,
+            "executable": executable,
+            "path": discovered_path,
+            "status": status.value,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True)
+class KitTestReuseCapabilityFact:
+    capability_id: KitTestReuseCapabilityName
+    status: KitTestReuseCapabilityStatus
+    reason_code: str
+    executable: str
+    discovered_path: str | None = None
+    fingerprint: str = ""
+    optional: bool = field(default=True, init=False)
+    blocking: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.capability_id, KitTestReuseCapabilityName):
+            object.__setattr__(
+                self, "capability_id", KitTestReuseCapabilityName(self.capability_id)
+            )
+        if not isinstance(self.status, KitTestReuseCapabilityStatus):
+            object.__setattr__(
+                self, "status", KitTestReuseCapabilityStatus(self.status)
+            )
+        if type(self.reason_code) is not str or not self.reason_code.strip():
+            raise ValueError("reason_code must be a nonempty string")
+        if type(self.executable) is not str or not self.executable:
+            raise ValueError("executable must be a nonempty string")
+        if self.discovered_path is not None and type(self.discovered_path) is not str:
+            raise ValueError("discovered_path must be a string or None")
+        expected = _fingerprint(
+            self.capability_id,
+            self.status,
+            self.executable,
+            self.discovered_path,
+        )
+        if self.fingerprint and self.fingerprint != expected:
+            raise ValueError("capability fingerprint does not match its facts")
+        object.__setattr__(self, "fingerprint", expected)
+
+    @property
+    def name(self) -> str:
+        return self.capability_id.value
+
+    @property
+    def available(self) -> bool:
+        return self.status is KitTestReuseCapabilityStatus.AVAILABLE
+
+    @property
+    def test_action(self) -> str:
+        return "continue" if self.available else "run"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "capability_id": self.capability_id.value,
+            "status": self.status.value,
+            "reason_code": self.reason_code,
+            "executable": self.executable,
+            "discovered_path": self.discovered_path,
+            "fingerprint": self.fingerprint,
+            "available": self.available,
+            "optional": True,
+            "blocking": False,
+            "test_action": self.test_action,
+        }
+
+
+@dataclass(frozen=True)
+class KitTestReuseCapabilityReport:
+    capabilities: tuple[KitTestReuseCapabilityFact, ...]
+    probe_count: int
+    mode: str | None = None
+    schema_version: str = TEST_REUSE_CAPABILITY_REPORT_SCHEMA
+    report_version: int = TEST_REUSE_CAPABILITY_REPORT_VERSION
+    lazy: bool = field(default=True, init=False)
+    bounded: bool = field(default=True, init=False)
+    side_effect_free: bool = field(default=True, init=False)
+    network_attempted: bool = field(default=False, init=False)
+    daemon_started: bool = field(default=False, init=False)
+    user_ipfs_directory_touched: bool = field(default=False, init=False)
+    cache_created: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        facts = tuple(self.capabilities)
+        if tuple(fact.capability_id for fact in facts) != _CAPABILITY_ORDER:
+            raise ValueError("capabilities must appear once in Kubo/Lotus/Iroh order")
+        if (
+            isinstance(self.probe_count, bool)
+            or not isinstance(self.probe_count, int)
+            or self.probe_count < 0
+        ):
+            raise ValueError("probe_count must be a non-negative integer")
+        object.__setattr__(self, "capabilities", facts)
+        normalized = self.mode.strip().lower() if type(self.mode) is str else None
+        object.__setattr__(self, "mode", normalized or None)
+
+    @property
+    def facts(self) -> Mapping[str, KitTestReuseCapabilityFact]:
+        return {fact.name: fact for fact in self.capabilities}
+
+    def capability(
+        self, capability_id: KitTestReuseCapabilityName | str
+    ) -> KitTestReuseCapabilityFact:
+        key = (
+            capability_id.value
+            if isinstance(capability_id, KitTestReuseCapabilityName)
+            else str(capability_id)
+        )
+        try:
+            return self.facts[key]
+        except KeyError as exc:
+            raise KeyError(f"unknown kit test-reuse capability: {key}") from exc
+
+    @property
+    def all_optional(self) -> bool:
+        return all(fact.optional and not fact.blocking for fact in self.capabilities)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "report_version": self.report_version,
+            "mode": self.mode,
+            "probe_count": self.probe_count,
+            "lazy": True,
+            "bounded": True,
+            "side_effect_free": True,
+            "network_attempted": False,
+            "daemon_started": False,
+            "user_ipfs_directory_touched": False,
+            "cache_created": False,
+            "all_optional": self.all_optional,
+            "capabilities": {fact.name: fact.to_dict() for fact in self.capabilities},
+        }
+
+
+@dataclass(frozen=True)
+class KitTestReuseCapabilityConfig:
+    timeout_seconds: float = DEFAULT_CAPABILITY_TIMEOUT_SECONDS
+    max_checks: int = DEFAULT_CAPABILITY_MAX_CHECKS
+    disabled_capabilities: frozenset[KitTestReuseCapabilityName | str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or not math.isfinite(float(self.timeout_seconds))
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError("timeout_seconds must be finite and positive")
+        if (
+            isinstance(self.max_checks, bool)
+            or not isinstance(self.max_checks, int)
+            or self.max_checks < 1
+        ):
+            raise ValueError("max_checks must be a positive integer")
+        disabled = frozenset(
+            item
+            if isinstance(item, KitTestReuseCapabilityName)
+            else KitTestReuseCapabilityName(str(item))
+            for item in self.disabled_capabilities
+        )
+        object.__setattr__(self, "timeout_seconds", float(self.timeout_seconds))
+        object.__setattr__(self, "disabled_capabilities", disabled)
+
+
+@dataclass
+class _ProbeBudget:
+    timeout_seconds: float
+    max_checks: int
+    monotonic: Callable[[], float]
+    started: float = field(init=False)
+    count: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        self.started = self.monotonic()
+
+    def call(self, function: Callable[[str], Any], argument: str) -> tuple[str, Any]:
+        if self.count >= self.max_checks:
+            return "exhausted", None
+        elapsed = self.monotonic() - self.started
+        remaining = self.timeout_seconds - elapsed
+        if remaining <= 0:
+            return "exhausted", None
+        self.count += 1
+        result: list[tuple[bool, Any]] = []
+
+        def invoke() -> None:
+            try:
+                result.append((True, function(argument)))
+            except BaseException:
+                result.append((False, None))
+
+        worker = threading.Thread(
+            target=invoke,
+            name="ipfs-kit-cold-capability-probe",
+            daemon=True,
+        )
+        worker.start()
+        worker.join(remaining)
+        if worker.is_alive():
+            return "timeout", None
+        if not result or not result[0][0]:
+            return "failed", None
+        return "ok", result[0][1]
+
+
+def _environment_value(source: Mapping[str, str], key: str) -> str:
+    try:
+        value = source[key]
+    except KeyError:
+        return ""
+    if type(value) is not str:
+        raise TypeError("environment values must be strings")
+    return value.strip().lower()
+
+
+class KitTestReuseCapabilities:
+    """Lazy reporter; construction retains hooks but performs no checks."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        config: KitTestReuseCapabilityConfig | None = None,
+        *,
+        which: Callable[[str], str | None] | None = None,
+        environ: Mapping[str, str] | None = None,
+        monotonic: Callable[[], float] | None = None,
+    ) -> None:
+        self.config = config or KitTestReuseCapabilityConfig()
+        self._which = which or shutil.which
+        self._environ = os.environ if environ is None else environ
+        self._monotonic = monotonic or time.monotonic
+
+    def probe(self) -> KitTestReuseCapabilityReport:
+        """Return one non-cached snapshot of cold executable facts."""
+
+        try:
+            mode = _environment_value(
+                self._environ, "IPFS_TEST_PROOF_REUSE_MODE"
+            )
+        except BaseException:
+            mode = ""
+            mode_failed = True
+        else:
+            mode_failed = False
+
+        if mode_failed:
+            facts = tuple(
+                self._fact(
+                    capability,
+                    KitTestReuseCapabilityStatus.UNKNOWN,
+                    "configuration_probe_failed",
+                )
+                for capability in _CAPABILITY_ORDER
+            )
+            return KitTestReuseCapabilityReport(facts, 0)
+
+        if mode in _DISABLED_VALUES:
+            facts = tuple(
+                self._fact(
+                    capability,
+                    KitTestReuseCapabilityStatus.DISABLED,
+                    "proof_reuse_disabled",
+                )
+                for capability in _CAPABILITY_ORDER
+            )
+            return KitTestReuseCapabilityReport(facts, 0, mode)
+
+        budget = _ProbeBudget(
+            self.config.timeout_seconds, self.config.max_checks, self._monotonic
+        )
+        facts = tuple(self._probe_one(capability, budget) for capability in _CAPABILITY_ORDER)
+        return KitTestReuseCapabilityReport(facts, budget.count, mode or None)
+
+    report = probe
+    snapshot = probe
+
+    def _probe_one(
+        self,
+        capability: KitTestReuseCapabilityName,
+        budget: _ProbeBudget,
+    ) -> KitTestReuseCapabilityFact:
+        if capability in self.config.disabled_capabilities:
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.DISABLED,
+                "capability_disabled",
+            )
+        label = capability.value.upper()
+        try:
+            explicitly_disabled = _environment_value(
+                self._environ, f"IPFS_TEST_PROOF_REUSE_DISABLE_{label}"
+            )
+            explicitly_enabled = _environment_value(
+                self._environ, f"IPFS_TEST_PROOF_REUSE_{label}_ENABLED"
+            )
+        except BaseException:
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.UNKNOWN,
+                "configuration_probe_failed",
+            )
+        if (
+            explicitly_disabled in _ENABLED_VALUES
+            or explicitly_enabled in _DISABLED_VALUES
+        ):
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.DISABLED,
+                "capability_disabled",
+            )
+
+        executable = _EXECUTABLES[capability]
+        outcome, discovered = budget.call(self._which, executable)
+        if outcome == "timeout":
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.UNKNOWN,
+                "probe_timed_out",
+            )
+        if outcome != "ok":
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.UNKNOWN,
+                "probe_budget_exhausted" if outcome == "exhausted" else "probe_failed",
+            )
+        if discovered is None:
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.MISSING,
+                "executable_missing",
+            )
+        if type(discovered) is not str or not discovered.strip():
+            return self._fact(
+                capability,
+                KitTestReuseCapabilityStatus.INCOMPATIBLE,
+                "executable_finder_incompatible",
+            )
+        return self._fact(
+            capability,
+            KitTestReuseCapabilityStatus.AVAILABLE,
+            "executable_discovered",
+            discovered.strip(),
+        )
+
+    @staticmethod
+    def _fact(
+        capability: KitTestReuseCapabilityName,
+        status: KitTestReuseCapabilityStatus,
+        reason: str,
+        path: str | None = None,
+    ) -> KitTestReuseCapabilityFact:
+        return KitTestReuseCapabilityFact(
+            capability, status, reason, _EXECUTABLES[capability], path
+        )
+
+
+def probe_kit_test_reuse_capabilities(
+    config: KitTestReuseCapabilityConfig | None = None,
+    **kwargs: Any,
+) -> KitTestReuseCapabilityReport:
+    return KitTestReuseCapabilities(config, **kwargs).probe()
+
+
+__all__ = [
+    "DEFAULT_CAPABILITY_MAX_CHECKS",
+    "DEFAULT_CAPABILITY_TIMEOUT_SECONDS",
+    "KitTestReuseCapabilities",
+    "KitTestReuseCapabilityConfig",
+    "KitTestReuseCapabilityFact",
+    "KitTestReuseCapabilityName",
+    "KitTestReuseCapabilityReport",
+    "KitTestReuseCapabilityStatus",
+    "TEST_REUSE_CAPABILITY_REPORT_SCHEMA",
+    "TEST_REUSE_CAPABILITY_REPORT_SCHEMA_VERSION",
+    "TEST_REUSE_CAPABILITY_REPORT_VERSION",
+    "probe_kit_test_reuse_capabilities",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,9 @@ ipfs-kit-iroh-interop = "ipfs_kit_py.iroh.multinode:main"
 iroh = "ipfs_kit_py.iroh_fsspec:IrohFileSystem"
 "iroh+blob" = "ipfs_kit_py.iroh_fsspec:IrohFileSystem"
 
+[project.entry-points.pytest11]
+ipfs-proof-reuse = "ipfs_accelerate_py.testing.proof_reuse.plugin"
+
 [project.urls]
 Homepage = "https://github.com/endomorphosis/ipfs_kit_py/"
 Documentation = "https://github.com/endomorphosis/ipfs_kit_py/blob/main/README.md"

--- a/tests/test_proof_certificate_store.py
+++ b/tests/test_proof_certificate_store.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from ipfs_kit_py.proof_certificate_store import (
+    CertificateTransportReason,
+    CertificateTransportStatus,
+    IpfsKitProofCertificateStore,
+    cid_for_certificate_bytes,
+    decode_certificate_cid,
+    verify_certificate_cid,
+)
+
+
+def _varint(value: int) -> bytes:
+    result = bytearray()
+    while value >= 0x80:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value)
+    return bytes(result)
+
+
+def _external_cid(data: bytes, codec: int = 0x0129) -> str:
+    raw = (
+        _varint(1)
+        + _varint(codec)
+        + _varint(0x12)
+        + _varint(32)
+        + hashlib.sha256(data).digest()
+    )
+    return "b" + base64.b32encode(raw).decode().lower().rstrip("=")
+
+
+def test_external_cid_decodes_and_rehashes_exact_bytes(tmp_path: Path) -> None:
+    data = b'{"certificate":"external","passed":true}'
+    external = _external_cid(data)
+    parsed = decode_certificate_cid(external)
+    assert parsed.codec == 0x0129
+    assert parsed.verifies(data)
+    assert verify_certificate_cid(external, data)
+    assert not verify_certificate_cid(external, data + b"\n")
+
+    store = IpfsKitProofCertificateStore(tmp_path)
+    put = store.put_bytes(data, claimed_cid=external)
+    assert put.stored and put.cid == external
+    result = store.get_bytes(external)
+    assert result.status is CertificateTransportStatus.HIT
+    assert result.data == data
+
+
+@pytest.mark.parametrize(
+    "fake",
+    [
+        "QmTest0123456789abcdef0123456789abcdef",
+        "bafy-test-certificate",
+        "bafkreifake",
+        "sha256:" + "0" * 64,
+    ],
+)
+def test_legacy_fake_hashes_are_rejected(tmp_path: Path, fake: str) -> None:
+    store = IpfsKitProofCertificateStore(tmp_path)
+    assert not store.put_bytes(b"certificate", claimed_cid=fake)
+    miss = store.get_bytes(fake)
+    assert not miss.hit
+    assert miss.reason_code is CertificateTransportReason.MALFORMED
+
+
+def test_local_transport_is_atomic_bounded_and_rehashed(tmp_path: Path) -> None:
+    store = IpfsKitProofCertificateStore(tmp_path, max_blob_bytes=32)
+    data = b"exact-certificate"
+    cid = cid_for_certificate_bytes(data)
+    assert store.put(data) == cid
+    assert store.get(cid) == data
+    assert not list(tmp_path.rglob("*.tmp"))
+
+    second = store.put_bytes(data, claimed_cid=cid)
+    assert second.stored
+    assert second.reason_code is CertificateTransportReason.ALREADY_EXISTS
+
+    oversized = store.put_bytes(b"x" * 33)
+    assert not oversized
+    assert oversized.reason_code is CertificateTransportReason.OVER_BUDGET
+
+    blob = next(tmp_path.rglob("*.blob"))
+    blob.write_bytes(b"changed")
+    corrupt = store.get_bytes(cid)
+    assert not corrupt.hit
+    assert corrupt.reason_code is CertificateTransportReason.INTEGRITY_FAILED
+
+
+def test_local_transport_rejects_symlink_blob(tmp_path: Path) -> None:
+    data = b"certificate"
+    cid = cid_for_certificate_bytes(data)
+    store = IpfsKitProofCertificateStore(tmp_path)
+    path = store._blob_path(cid)
+    path.parent.mkdir(parents=True)
+    target = tmp_path / "outside"
+    target.write_bytes(data)
+    path.symlink_to(target)
+    result = store.get_bytes(cid)
+    assert not result.hit
+    assert result.reason_code is CertificateTransportReason.SYMLINK_REJECTED
+
+
+def test_local_transport_does_not_create_through_symlink_directory(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "cache"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (root / "certificates").symlink_to(outside, target_is_directory=True)
+
+    result = IpfsKitProofCertificateStore(root).put_bytes(b"certificate")
+
+    assert not result.stored
+    assert result.reason_code is CertificateTransportReason.SYMLINK_REJECTED
+    assert not list(outside.iterdir())
+
+
+def test_ipfs_error_is_a_miss_and_never_raises() -> None:
+    calls: list[str] = []
+
+    def failing_get(cid: str) -> bytes:
+        calls.append(cid)
+        raise RuntimeError("daemon unavailable")
+
+    cid = cid_for_certificate_bytes(b"certificate")
+    store = IpfsKitProofCertificateStore(ipfs_get=failing_get)
+    result = store.get_bytes(cid)
+    assert calls == [cid]
+    assert not result.hit
+    assert result.reason_code is CertificateTransportReason.IPFS_ERROR
+
+
+def test_ipfs_bytes_are_bounded_verified_and_optionally_cached(tmp_path: Path) -> None:
+    data = b"remote certificate"
+    cid = _external_cid(data)
+    calls: list[str] = []
+
+    def get_remote(requested: str) -> bytes:
+        calls.append(requested)
+        return data
+
+    store = IpfsKitProofCertificateStore(tmp_path, ipfs_get=get_remote)
+    first = store.get_bytes(cid)
+    assert first.hit and first.source == "ipfs" and first.data == data
+    second = store.get_bytes(cid)
+    assert second.hit and second.source == "local"
+    assert calls == [cid]
+
+    mismatch = IpfsKitProofCertificateStore(ipfs_get=lambda unused: data + b"!")
+    assert mismatch.get_bytes(cid).reason_code is CertificateTransportReason.INTEGRITY_FAILED
+
+    oversized = IpfsKitProofCertificateStore(
+        ipfs_get=lambda unused: b"x" * 9, max_blob_bytes=8
+    )
+    assert oversized.get_bytes(cid).reason_code is CertificateTransportReason.IPFS_RESPONSE_INVALID
+
+
+def test_default_store_has_no_filesystem_or_ipfs_side_effect(tmp_path: Path) -> None:
+    store = IpfsKitProofCertificateStore()
+    cid = cid_for_certificate_bytes(b"certificate")
+    assert not store.put_bytes(b"certificate", claimed_cid=cid)
+    assert store.get(cid) is None
+    assert not list(tmp_path.iterdir())
+
+
+def test_ipfs_put_response_must_carry_exact_byte_digest() -> None:
+    data = b"certificate"
+    expected = cid_for_certificate_bytes(data)
+    wrong = cid_for_certificate_bytes(b"other")
+    bad = IpfsKitProofCertificateStore(ipfs_put=lambda payload: {"Key": wrong})
+    result = bad.put_bytes(data, claimed_cid=expected)
+    assert not result.stored
+    assert result.reason_code is CertificateTransportReason.CID_MISMATCH
+
+    good = IpfsKitProofCertificateStore(ipfs_put=lambda payload: {"Key": expected})
+    assert good.put_bytes(data, claimed_cid=expected).ipfs_stored

--- a/tests/test_proof_reuse_bootstrap.py
+++ b/tests/test_proof_reuse_bootstrap.py
@@ -13,11 +13,55 @@ from pathlib import Path
 import pytest
 
 KIT_ROOT = Path(__file__).resolve().parents[1]
-ACCELERATE_ROOT = KIT_ROOT.parent / "ipfs_accelerate"
+
+
+def _resolve_accelerate_root() -> Path | None:
+    """Locate an accelerate checkout that carries proof-reuse plugins.
+
+    Standalone ipfs_kit_py CI does not always vendor a sibling accelerate tree.
+    Prefer an explicit env override, then common monorepo/sibling layouts.
+    """
+
+    candidates: list[Path] = []
+    env = os.environ.get("IPFS_ACCELERATE_ROOT") or os.environ.get(
+        "IPFS_ACCELERATE_PY_ROOT"
+    )
+    if env:
+        candidates.append(Path(env))
+    candidates.extend(
+        (
+            KIT_ROOT.parent / "ipfs_accelerate",
+            KIT_ROOT.parent / "ipfs_accelerate_py",
+            KIT_ROOT.parent.parent / "external" / "ipfs_accelerate",
+            KIT_ROOT.parent / "external" / "ipfs_accelerate",
+        )
+    )
+    for candidate in candidates:
+        plugin = (
+            candidate
+            / "ipfs_accelerate_py"
+            / "testing"
+            / "proof_reuse"
+            / "plugin.py"
+        )
+        if plugin.is_file():
+            return candidate
+    return None
+
+
+ACCELERATE_ROOT = _resolve_accelerate_root()
 BOOTSTRAP = KIT_ROOT / "conftest.py"
 PLUGIN_MODULE = "ipfs_accelerate_py.testing.proof_reuse.plugin"
 PLUGIN_ENTRY_POINT = "ipfs-proof-reuse"
 PYTEST_SITE = Path(pytest.__file__).resolve().parents[1]
+
+pytestmark = pytest.mark.skipif(
+    ACCELERATE_ROOT is None,
+    reason=(
+        "ipfs_accelerate_py proof-reuse plugin not found; set "
+        "IPFS_ACCELERATE_ROOT to enable integration bootstrap tests"
+    ),
+)
 
 
 def _write(path: Path, source: str) -> None:
@@ -37,6 +81,8 @@ def _environment(
     first_paths: tuple[Path, ...] = (),
 ) -> dict[str, str]:
     environment = dict(os.environ)
+    if ACCELERATE_ROOT is None:
+        raise RuntimeError("ACCELERATE_ROOT is required for bootstrap integration tests")
     python_paths = (
         *(str(path) for path in first_paths),
         str(ACCELERATE_ROOT),

--- a/tests/test_proof_reuse_bootstrap.py
+++ b/tests/test_proof_reuse_bootstrap.py
@@ -1,0 +1,361 @@
+"""Integration tests for ipfs_kit's optional proof-reuse bootstrap."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+import tomllib
+from pathlib import Path
+
+import pytest
+
+KIT_ROOT = Path(__file__).resolve().parents[1]
+ACCELERATE_ROOT = KIT_ROOT.parent / "ipfs_accelerate"
+BOOTSTRAP = KIT_ROOT / "conftest.py"
+PLUGIN_MODULE = "ipfs_accelerate_py.testing.proof_reuse.plugin"
+PLUGIN_ENTRY_POINT = "ipfs-proof-reuse"
+PYTEST_SITE = Path(pytest.__file__).resolve().parents[1]
+
+
+def _write(path: Path, source: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+
+
+def _copy_bootstrap(project: Path) -> None:
+    shutil.copy2(BOOTSTRAP, project / "conftest.py")
+
+
+def _environment(
+    tmp_path: Path,
+    *,
+    mode: str,
+    autoload: bool,
+    first_paths: tuple[Path, ...] = (),
+) -> dict[str, str]:
+    environment = dict(os.environ)
+    python_paths = (
+        *(str(path) for path in first_paths),
+        str(ACCELERATE_ROOT),
+        str(KIT_ROOT),
+        str(PYTEST_SITE),
+        environment.get("PYTHONPATH", ""),
+    )
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in python_paths if part
+    )
+    environment["IPFS_TEST_PROOF_REUSE_MODE"] = mode
+    environment["HOME"] = str(tmp_path / "user-home")
+    environment["IPFS_PATH"] = str(tmp_path / "user-home" / ".ipfs")
+    environment["COVERAGE_FILE"] = str(tmp_path / ".coverage")
+    environment.pop("PYTEST_ADDOPTS", None)
+    if autoload:
+        environment.pop("PYTEST_DISABLE_PLUGIN_AUTOLOAD", None)
+    else:
+        environment["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    return environment
+
+
+def _run_pytest(
+    project: Path,
+    environment: dict[str, str],
+    *arguments: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *arguments],
+        cwd=project,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _assert_success(
+    completed: subprocess.CompletedProcess[str],
+    expected: str,
+) -> None:
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == 0, output
+    assert expected in output, output
+
+
+def _install_test_entry_point(metadata_root: Path) -> None:
+    distribution = metadata_root / "ipfs_kit_ptr_bootstrap-0.dist-info"
+    _write(
+        distribution / "METADATA",
+        """
+        Metadata-Version: 2.1
+        Name: ipfs-kit-ptr-bootstrap
+        Version: 0
+        """,
+    )
+    _write(
+        distribution / "entry_points.txt",
+        f"""
+        [pytest11]
+        {PLUGIN_ENTRY_POINT} = {PLUGIN_MODULE}
+        """,
+    )
+
+
+def test_pyproject_declares_shared_pytest_entry_point() -> None:
+    project = tomllib.loads(
+        (KIT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert (
+        project["project"]["entry-points"]["pytest11"][PLUGIN_ENTRY_POINT]
+        == PLUGIN_MODULE
+    )
+
+
+@pytest.mark.parametrize("autoload", [False, True], ids=["root-fallback", "entry-point"])
+def test_direct_node_pickup_with_entry_point_autoload_modes(
+    tmp_path: Path,
+    autoload: bool,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _copy_bootstrap(project)
+    _write(
+        project / "test_direct_node.py",
+        f"""
+        import pytest
+
+        from {PLUGIN_MODULE} import get_item_metadata
+
+        @pytest.mark.proof_reuse_effects("filesystem")
+        def test_direct_node(request, pytestconfig):
+            metadata = get_item_metadata(request.node)
+            assert metadata is not None
+            assert metadata.nodeid.endswith("test_direct_node.py::test_direct_node")
+            assert metadata.effect_adapters == ("filesystem",)
+            assert pytestconfig.pluginmanager.hasplugin("{PLUGIN_ENTRY_POINT}") is {
+                autoload!r
+            }
+        """,
+    )
+    metadata_root = tmp_path / "metadata"
+    first_paths: tuple[Path, ...] = ()
+    if autoload:
+        _install_test_entry_point(metadata_root)
+        first_paths = (metadata_root,)
+    environment = _environment(
+        tmp_path,
+        mode="shadow",
+        autoload=autoload,
+        first_paths=first_paths,
+    )
+
+    completed = _run_pytest(
+        project,
+        environment,
+        "test_direct_node.py::test_direct_node",
+        "-q",
+    )
+
+    _assert_success(completed, "1 passed")
+
+
+def test_verified_hit_skips_before_fixtures_without_ipfs_or_daemon_touch(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    tests = project / "tests"
+    tests.mkdir(parents=True)
+    _copy_bootstrap(project)
+    daemon_sentinel = tmp_path / "daemon-started"
+    body_sentinel = tmp_path / "test-body-ran"
+    _write(
+        tests / "conftest.py",
+        f"""
+        from pathlib import Path
+
+        import pytest
+
+        from ipfs_accelerate_py.agent_supervisor.proof.test_execution_contracts import (
+            reuse_skip,
+        )
+        from ipfs_accelerate_py.testing.proof_reuse.lookup import ProofReuseLookup
+        from ipfs_accelerate_py.testing.proof_reuse.plugin import (
+            set_proof_reuse_services,
+        )
+
+        class VerifiedHitLookup(ProofReuseLookup):
+            def lookup(self, locator, execution_key, **kwargs):
+                return reuse_skip(
+                    certificate_cid="bafy-test-certificate",
+                    receipt_cid="bafy-test-receipt",
+                )
+
+        def pytest_configure(config):
+            set_proof_reuse_services(config, lookup=VerifiedHitLookup())
+
+        @pytest.hookimpl(tryfirst=True)
+        def pytest_collection_modifyitems(items):
+            for item in items:
+                item._ipfs_proof_reuse_locator = object()
+                item._ipfs_proof_reuse_execution_key = object()
+
+        @pytest.fixture(autouse=True)
+        def would_start_daemon():
+            Path({str(daemon_sentinel)!r}).write_text("started", encoding="utf-8")
+        """,
+    )
+    _write(
+        tests / "test_hit.py",
+        f"""
+        from pathlib import Path
+
+        def test_cached_pass():
+            Path({str(body_sentinel)!r}).write_text("ran", encoding="utf-8")
+        """,
+    )
+    environment = _environment(tmp_path, mode="read", autoload=False)
+    user_ipfs_path = Path(environment["IPFS_PATH"])
+
+    completed = _run_pytest(
+        project,
+        environment,
+        "tests/test_hit.py::test_cached_pass",
+        "-q",
+        "-rs",
+    )
+
+    _assert_success(completed, "1 skipped")
+    assert "proof-cache-hit:bafy-test-certificate" in completed.stdout
+    assert not daemon_sentinel.exists()
+    assert not body_sentinel.exists()
+    assert not user_ipfs_path.exists()
+
+
+def test_missing_shared_plugin_executes_normally(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _copy_bootstrap(project)
+    _write(project / "test_normal.py", "def test_normal():\n    assert True\n")
+    blockers = tmp_path / "blockers"
+    _write(
+        blockers / "sitecustomize.py",
+        """
+        import importlib.abc
+        import sys
+
+        class BlockProofReuse(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "ipfs_accelerate_py" or fullname.startswith(
+                    "ipfs_accelerate_py."
+                ):
+                    raise ModuleNotFoundError(
+                        "optional proof-reuse plugin unavailable",
+                        name=fullname,
+                    )
+                return None
+
+        sys.meta_path.insert(0, BlockProofReuse())
+        """,
+    )
+    environment = _environment(
+        tmp_path,
+        mode="read",
+        autoload=False,
+        first_paths=(blockers,),
+    )
+
+    completed = _run_pytest(project, environment, "test_normal.py", "-q")
+
+    _assert_success(completed, "1 passed")
+
+
+def test_missing_store_and_multiformats_execute_normally(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _copy_bootstrap(project)
+    _write(project / "test_normal.py", "def test_normal():\n    assert True\n")
+    blockers = tmp_path / "blockers"
+    _write(
+        blockers / "sitecustomize.py",
+        """
+        import importlib.abc
+        import sys
+
+        BLOCKED = ("ipfs_kit_py.proof_certificate_store", "multiformats")
+
+        class BlockOptionalProviders(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if any(
+                    fullname == name or fullname.startswith(name + ".")
+                    for name in BLOCKED
+                ):
+                    raise AssertionError("optional provider imported: " + fullname)
+                return None
+
+        sys.meta_path.insert(0, BlockOptionalProviders())
+        """,
+    )
+    environment = _environment(
+        tmp_path,
+        mode="shadow",
+        autoload=False,
+        first_paths=(blockers,),
+    )
+
+    completed = _run_pytest(project, environment, "test_normal.py", "-q")
+
+    _assert_success(completed, "1 passed")
+
+
+def test_explicit_off_mode_executes_normally(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _copy_bootstrap(project)
+    _write(
+        project / "test_off.py",
+        f"""
+        from {PLUGIN_MODULE} import ProofReuseMode, get_proof_reuse_config
+
+        def test_off(pytestconfig):
+            assert get_proof_reuse_config(pytestconfig).mode is ProofReuseMode.OFF
+        """,
+    )
+    environment = _environment(tmp_path, mode="off", autoload=False)
+
+    completed = _run_pytest(project, environment, "test_off.py", "-q")
+
+    _assert_success(completed, "1 passed")
+
+
+def test_coverage_execution_remains_available(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _copy_bootstrap(project)
+    _write(
+        project / "test_coverage_target.py",
+        """
+        def covered_value():
+            return 42
+
+        def test_covered_value():
+            assert covered_value() == 42
+        """,
+    )
+    environment = _environment(tmp_path, mode="off", autoload=False)
+
+    completed = _run_pytest(
+        project,
+        environment,
+        "-p",
+        "pytest_cov.plugin",
+        "--cov=test_coverage_target",
+        "--cov-report=term",
+        "test_coverage_target.py",
+        "-q",
+    )
+
+    _assert_success(completed, "1 passed")
+    assert "TOTAL" in completed.stdout

--- a/tests/test_reuse_capabilities.py
+++ b/tests/test_reuse_capabilities.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+from ipfs_kit_py.test_reuse_capabilities import (
+    KitTestReuseCapabilities,
+    KitTestReuseCapabilityConfig,
+    KitTestReuseCapabilityStatus,
+    TEST_REUSE_CAPABILITY_REPORT_SCHEMA,
+)
+
+
+def test_construction_is_lazy_and_off_mode_performs_no_discovery() -> None:
+    calls: list[str] = []
+
+    def which(name: str) -> str | None:
+        calls.append(name)
+        raise AssertionError("off mode must not discover executables")
+
+    capabilities = KitTestReuseCapabilities(
+        which=which, environ={"IPFS_TEST_PROOF_REUSE_MODE": "off"}
+    )
+    assert calls == []
+    report = capabilities.probe()
+    assert calls == []
+    assert report.probe_count == 0
+    assert all(
+        fact.status is KitTestReuseCapabilityStatus.DISABLED
+        for fact in report.capabilities
+    )
+
+
+def test_kubo_lotus_and_iroh_are_stable_lazy_facts() -> None:
+    calls: list[str] = []
+    paths = {"ipfs": "/opt/bin/ipfs", "lotus": None, "iroh": "/opt/bin/iroh"}
+
+    def which(name: str) -> str | None:
+        calls.append(name)
+        return paths[name]
+
+    capabilities = KitTestReuseCapabilities(which=which, environ={})
+    assert calls == []
+    report = capabilities.snapshot()
+    assert calls == ["ipfs", "lotus", "iroh"]
+    assert tuple(report.facts) == ("kubo", "lotus", "iroh")
+    assert report.capability("kubo").status is KitTestReuseCapabilityStatus.AVAILABLE
+    assert report.capability("lotus").status is KitTestReuseCapabilityStatus.MISSING
+    assert report.capability("iroh").status is KitTestReuseCapabilityStatus.AVAILABLE
+    assert all(fact.fingerprint.startswith("sha256:") for fact in report.capabilities)
+
+    encoded = json.dumps(report.to_dict(), sort_keys=True)
+    assert TEST_REUSE_CAPABILITY_REPORT_SCHEMA in encoded
+    assert report.lazy and report.bounded and report.side_effect_free
+    assert not report.network_attempted
+    assert not report.daemon_started
+    assert not report.user_ipfs_directory_touched
+    assert not report.cache_created
+
+
+def test_capabilities_never_execute_or_start_discovered_daemons(monkeypatch) -> None:
+    def forbidden(*args, **kwargs):
+        raise AssertionError("capability facts must not start or execute a daemon")
+
+    monkeypatch.setattr("subprocess.Popen", forbidden)
+    monkeypatch.setattr("subprocess.run", forbidden)
+    report = KitTestReuseCapabilities(
+        which=lambda name: f"/safe/{name}", environ={}
+    ).probe()
+    assert report.probe_count == 3
+    assert all(fact.available for fact in report.capabilities)
+
+
+def test_explicit_disables_are_optional_nonblocking_facts() -> None:
+    calls: list[str] = []
+    config = KitTestReuseCapabilityConfig(disabled_capabilities=frozenset({"lotus"}))
+    report = KitTestReuseCapabilities(
+        config,
+        which=lambda name: calls.append(name) or f"/bin/{name}",
+        environ={"IPFS_TEST_PROOF_REUSE_DISABLE_IROH": "true"},
+    ).report()
+    assert calls == ["ipfs"]
+    assert report.capability("kubo").available
+    assert report.capability("lotus").status is KitTestReuseCapabilityStatus.DISABLED
+    assert report.capability("iroh").status is KitTestReuseCapabilityStatus.DISABLED
+    assert all(fact.optional and not fact.blocking for fact in report.capabilities)
+    assert report.capability("lotus").test_action == "run"
+
+
+def test_probe_budget_fails_closed_without_extra_checks() -> None:
+    calls: list[str] = []
+    config = KitTestReuseCapabilityConfig(max_checks=1)
+    report = KitTestReuseCapabilities(
+        config,
+        which=lambda name: calls.append(name) or None,
+        environ={},
+    ).probe()
+    assert calls == ["ipfs"]
+    assert report.probe_count == 1
+    assert report.capability("kubo").status is KitTestReuseCapabilityStatus.MISSING
+    assert report.capability("lotus").status is KitTestReuseCapabilityStatus.UNKNOWN
+    assert report.capability("iroh").status is KitTestReuseCapabilityStatus.UNKNOWN


### PR DESCRIPTION
## Summary
Land kit-side proof-reuse bootstrap from the `fix/proof-reuse-bootstrap` worktree onto current `origin/main`:

- PTR-080: strict optional certificate transport
- PTR-081: bootstrap proof reuse in ipfs_kit_py
- Lazy pytest bootstrap / installers

## Test plan
- [ ] CI green
- [ ] `tests/test_proof_certificate_store.py`
- [ ] `tests/test_proof_reuse_bootstrap.py`
- [ ] `tests/test_reuse_capabilities.py`